### PR TITLE
fixing passing of local addr bind options to threads.

### DIFF
--- a/include/is2/srvr/lsnr.h
+++ b/include/is2/srvr/lsnr.h
@@ -55,7 +55,8 @@ public:
         lsnr(uint16_t a_port=12345,
              scheme_t a_scheme = SCHEME_TCP,
              rqst_h* a_default_handler = NULL,
-             url_router* a_url_router = NULL);
+             url_router* a_url_router = NULL,
+             uint32_t a_local_addr_v4 = 0);
         ~lsnr();
         // Getters
         int32_t get_fd(void) const { return m_fd;}
@@ -68,6 +69,7 @@ public:
                 ao_sa_len = m_sa_len;
         }
         uint16_t get_port(void) { return m_port;}
+        uint32_t get_local_addr_v4(void) { return m_local_addr_v4;}
         // Setters
         int32_t set_local_addr_v4(const char *a_addr_str);
         int32_t set_default_route(rqst_h *a_handler);

--- a/src/srvr/lsnr.cc
+++ b/src/srvr/lsnr.cc
@@ -79,9 +79,10 @@ namespace ns_is2 {
 lsnr::lsnr(uint16_t a_port,
            scheme_t a_scheme,
            rqst_h* a_default_handler,
-           url_router* a_url_router):
+           url_router* a_url_router,
+           uint32_t a_local_addr_v4):
         m_scheme(a_scheme),
-        m_local_addr_v4(INADDR_ANY),
+        m_local_addr_v4(a_local_addr_v4),
         m_port(a_port),
         m_sa(),
         m_sa_len(0),
@@ -92,6 +93,10 @@ lsnr::lsnr(uint16_t a_port,
         m_fd(-1),
         m_is_initd(false)
 {
+        if(!m_local_addr_v4)
+        {
+                m_local_addr_v4 = INADDR_ANY;
+        }
         if(a_url_router)
         {
                 m_url_router = a_url_router;

--- a/src/srvr/srvr.cc
+++ b/src/srvr/srvr.cc
@@ -88,8 +88,8 @@ srvr::~srvr()
         // listener list
         // -------------------------------------------------
         for(lsnr_list_t::iterator i_t = m_lsnr_list.begin();
-                        i_t != m_lsnr_list.end();
-                        ++i_t)
+            i_t != m_lsnr_list.end();
+            ++i_t)
         {
                 if(*i_t)
                 {

--- a/src/srvr/t_srvr.cc
+++ b/src/srvr/t_srvr.cc
@@ -223,7 +223,8 @@ int32_t t_srvr::add_lsnr(lsnr &a_lsnr)
         lsnr* l_lsnr = new lsnr(a_lsnr.get_port(),
                                 a_lsnr.get_scheme(),
                                 a_lsnr.get_default_route(),
-                                a_lsnr.get_url_router());
+                                a_lsnr.get_url_router(),
+                                a_lsnr.get_local_addr_v4());
         l_s = l_lsnr->init();
         if(l_s != STATUS_OK)
         {


### PR DESCRIPTION
If address was specified to listener for binding, and bound address was not being passed the server thread listeners.
Adds new `lsnr` constructor arg with default value (`0`).