### PR TITLE
Update socket/connect check in configure due to implicit-function-dec…

### DIFF
--- a/ext/udns-0.4/configure
+++ b/ext/udns-0.4/configure
@@ -75,7 +75,13 @@ int main(int argc, char **argv) {
 EOF
 
 if ac_library_find_v 'socket and connect' "" "-lsocket -lnsl" <<EOF
-int main() { socket(); connect(); return 0; }
+#include <sys/types.h>
+#include <sys/socket.h>
+int main() {
+  socket(AF_INET, SOCK_STREAM, 0);
+  connect(0, 0, 0);
+  return 0;
+}
 EOF
 then :
 else


### PR DESCRIPTION
…laration treated as error on macos/clang

From Xcode 12 Release Notes:
> Clang now reports an error when you use a function without an explicit declaration when building C or Objective-C code for macOS (-Werror=implicit-function-declaration flag is on). This additional error detection unifies Clang’s behavior for iOS/tvOS and macOS 64-bit targets for this diagnostic. (49917738)

