### PR TITLE
adding cmake option to specify external openssl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,17 +9,18 @@ endif()
 # ------------------------------------------------------------------------------
 # Build options
 # ------------------------------------------------------------------------------
-option(GCC_OPTIONS       "Command line options passed to gcc or 'native' to compile for this hardware" OFF)
-option(FORTIFY           "Fortify Source GCC options" OFF)
-option(DEBUG_MODE        "Compile in debug mode." OFF)
-option(BUILD_TESTS       "Build the unit tests." ON)
-option(BUILD_EXAMPLES    "Build the examples." ON)
-option(BUILD_SYMBOLS     "Build with Symbols" ON)
-option(BUILD_UDNS        "Build with udns (async dns support)" ON)
-option(BUILD_TCMALLOC    "Build with tcmalloc" OFF)
-option(BUILD_PROFILER    "Enable google cpu and heap profiler support" OFF)
-option(BUILD_ASAN        "Build with Address Sanitizer" OFF)
-option(BUILD_UBSAN       "Build with Undefined Behavior Sanitizer" OFF)
+option(GCC_OPTIONS          "Command line options passed to gcc or 'native' to compile for this hardware" OFF)
+option(FORTIFY              "Fortify Source GCC options" OFF)
+option(DEBUG_MODE           "Compile in debug mode." OFF)
+option(BUILD_TESTS          "Build the unit tests." ON)
+option(BUILD_EXAMPLES       "Build the examples." ON)
+option(BUILD_SYMBOLS        "Build with Symbols" ON)
+option(BUILD_UDNS           "Build with udns (async dns support)" ON)
+option(BUILD_TCMALLOC       "Build with tcmalloc" OFF)
+option(BUILD_PROFILER       "Enable google cpu and heap profiler support" OFF)
+option(BUILD_ASAN           "Build with Address Sanitizer" OFF)
+option(BUILD_UBSAN          "Build with Undefined Behavior Sanitizer" OFF)
+option(BUILD_CUSTOM_OPENSSL "Build for openssl" OFF)
 # ------------------------------------------------------------------------------
 # Compiler options
 # ------------------------------------------------------------------------------
@@ -43,6 +44,7 @@ message("    Build with tcmalloc:                       " "BUILD_TCMALLOC       
 message("    Enable google cpu/heap profiler support:   " "BUILD_PROFILER          " ${BUILD_PROFILER})
 message("    Build with Address Sanitizer:              " "BUILD_ASAN              " ${BUILD_ASAN})
 message("    Build with Undefined Behavior Sanitizer:   " "BUILD_UBSAN             " ${BUILD_UBSAN})
+message("    Build for custom OpenSSL:                  " "BUILD_CUSTOM_OPENSSL    " ${BUILD_CUSTOM_OPENSSL})
 message("")
 IF(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
    # Mac OS X specific code
@@ -153,6 +155,14 @@ if (BUILD_TCMALLOC)
   set(LIBRARIES ${LIBRARIES} pthread)
 endif()
 # ------------------------------------------------------------------------------
+# special build case for OPENSSL
+# ------------------------------------------------------------------------------
+if(BUILD_CUSTOM_OPENSSL)
+  INCLUDE_DIRECTORIES("${BUILD_CUSTOM_OPENSSL}/include")
+  LINK_DIRECTORIES("${BUILD_CUSTOM_OPENSSL}")
+  LINK_DIRECTORIES("${BUILD_CUSTOM_OPENSSL}/lib")
+endif()
+# ------------------------------------------------------------------------------
 #
 # ------------------------------------------------------------------------------
 # make the cmake list variables into .deb-compatible strings
@@ -162,7 +172,7 @@ string(REPLACE ";" ", " CPACK_DEBIAN_PACKAGE_BUILDS_DEPENDS "${CPACK_DEBIAN_PACK
 # Version
 # ------------------------------------------------------------------------------
 EXECUTE_PROCESS(COMMAND git describe --tags OUTPUT_VARIABLE VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
-add_definitions(-DWAFLZ_VERSION="${VERSION}")
+add_definitions(-DIS2_VERSION="${VERSION}")
 # ------------------------------------------------------------------------------
 # Debian Package Support
 # ------------------------------------------------------------------------------

--- a/examples/w_stat.cc
+++ b/examples/w_stat.cc
@@ -43,8 +43,9 @@ int main(void)
 {
         ns_is2::srvr *l_srvr = new ns_is2::srvr();
         ns_is2::lsnr *l_lsnr = new ns_is2::lsnr(12345, ns_is2::SCHEME_TCP);
-        ns_is2::rqst_h *l_stat_h = new ns_is2::stat_h();
-        l_lsnr->add_route("/stat.json", l_stat_h);
+        ns_is2::stat_h *l_stat_h = new ns_is2::stat_h();
+        l_stat_h->set_route("/stat/*");
+        l_lsnr->add_route("/stat/*", l_stat_h);
         ns_is2::rqst_h *l_rqst_h = new base_handler();
         l_lsnr->set_default_route(l_rqst_h);
         l_srvr->register_lsnr(l_lsnr);

--- a/src/handler/stat/stat_h.cc
+++ b/src/handler/stat/stat_h.cc
@@ -18,9 +18,11 @@
 #include "is2/srvr/stat.h"
 #include "is2/handler/stat_h.h"
 #include "is2/support/ndebug.h"
+#include "rapidjson/rapidjson.h"
 #include "rapidjson/document.h"
 #include "rapidjson/stringbuffer.h"
 #include "rapidjson/prettywriter.h"
+#include <openssl/opensslv.h>
 namespace ns_is2 {
 //! ----------------------------------------------------------------------------
 //! \details: TODO
@@ -70,7 +72,6 @@ ns_is2::h_resp_t stat_h::do_get(ns_is2::session &a_session,
                 }
                 l_url_path = l_path.substr(l_idx, l_path.length() - l_route.length());
         }
-        //NDBG_PRINT("l_url_path: %s\n", l_url_path.c_str());
         // -------------------------------------------------
         // stats
         // -------------------------------------------------
@@ -176,10 +177,31 @@ ns_is2::h_resp_t stat_h::get_version(ns_is2::session &a_session,
         rapidjson::StringBuffer l_strbuf;
         rapidjson::Writer<rapidjson::StringBuffer> l_writer(l_strbuf);
         l_writer.StartObject();
+        // -------------------------------------------------
+        // is2 version
+        // -------------------------------------------------
         l_writer.Key("version");
         // TODO -add in is2 version..
-        l_writer.String("0.0.0");
+        l_writer.String(IS2_VERSION);
+        // -------------------------------------------------
+        // openssl version
+        // -------------------------------------------------
+        l_writer.Key("openssl_version");
+        // TODO -add in is2 version..
+        l_writer.String(OPENSSL_VERSION_TEXT);
+        // -------------------------------------------------
+        // openssl version
+        // -------------------------------------------------
+        l_writer.Key("rapidjson_version");
+        // TODO -add in is2 version..
+        l_writer.String(RAPIDJSON_VERSION_STRING);
+        // -------------------------------------------------
+        // end
+        // -------------------------------------------------
         l_writer.EndObject();
+        // -------------------------------------------------
+        // generate resp
+        // -------------------------------------------------
         ns_is2::api_resp &l_api_resp = ns_is2::create_api_resp(a_session);
         l_api_resp.add_std_headers(ns_is2::HTTP_STATUS_OK,
                                    "application/json",


### PR DESCRIPTION
## What is it?
Add external openssl option to build against (`BUILD_CUSTOM_OPENSSL`):
```
~/gproj/is2/build>cmake ../
-- Build Configuration:

    Build Option                               Variable                Value                 
    -----------------------------------------------------------------------------------------
    Debug mode:                                DEBUG_MODE              OFF
...
    Build for custom OpenSSL:                  BUILD_CUSTOM_OPENSSL    /home/rmorrison/archive/openssl
```

### Example
```
~/gproj/is2/build>cmake ../ -DBUILD_CUSTOM_OPENSSL=/home/rmorrison/archive/openssl
...
```

### Sample output (from `examples/w_stat`)
```
>curl -s 'localhost:12345/stat/version.json' | jq '.'
{
  "version": "0.0.0-31-gaf95940",
  "openssl_version": "OpenSSL 3.0.0-dev xx XXX xxxx",
  "rapidjson_version": "1.1.0"
}
```
